### PR TITLE
Add support for displaying flats instead of sharps

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,6 +33,9 @@
     <div id="bpm-select">
         <input type="number" id="bpm-input"><span>BPM</span>
     </div>
+    <div id="flats-checkbox">
+        <input type="checkbox" id="flats-input"><span>Use flats</span>
+    </div>
     <div id="start-button" class="noselect">
         Start
     </div>

--- a/main.js
+++ b/main.js
@@ -11,6 +11,7 @@ var SELECTED_STRING = "E";
 
 var IS_RUNNING = false;
 var NOTE_INDEX = 0;
+var USE_FLATS = false;
 
 //create a synth and connect it to the master output (your speakers)
 var SYNTH = new Tone.Synth().toMaster();
@@ -27,6 +28,8 @@ $('document').ready(function () {
     $("#bpm-input").val(60);
     changeBPM(60);
 
+    $("#flats-input").prop('checked', false);
+
     Tone.Transport.scheduleRepeat(function (time) {
         playNote(NOTE_INDEX);
     }, "4n");
@@ -39,6 +42,11 @@ $('document').ready(function () {
 
     $("#bpm-input").change(function () {
         changeBPM(parseInt($("#bpm-input").val()));
+    });
+
+    $("#flats-input").change(function () {
+        USE_FLATS = $("#flats-input").prop('checked');
+        makeNoteGrid(noteMap[SELECTED_STRING]);
     });
 
     footerAlign();
@@ -90,7 +98,18 @@ function playNote(noteIndex) {
 }
 
 function getDisplayNoteName(noteName) {
-    return getFixedNoteName(noteName).substring(0, noteName.length - 1);
+    displayName = getFixedNoteName(noteName).substring(0, noteName.length - 1);
+    if (USE_FLATS && displayName.length > 1){
+        note = displayName.substring(0, 1).charCodeAt();
+        note = String.fromCharCode(note + 1);
+        if (note === "H")
+            note = "A"
+        displayName = note + "♭";
+    } else {
+        displayName = displayName.replace("#", "♯")
+    }
+
+    return displayName;
 }
 
 function getFixedNoteName(noteName) {
@@ -175,4 +194,4 @@ function footerAlign() {
     var footerHeight = $('footer').outerHeight();
     $('body').css('padding-bottom', footerHeight);
     $('footer').css('height', footerHeight);
-  }
+}

--- a/style.css
+++ b/style.css
@@ -145,19 +145,19 @@ body {
                                     supported by Chrome and Opera */
   }
 
-  #bpm-input {
-      width: 75px;
-      border: 2px solid #CCCCCC;
-      font-size: 2.5em;
-      margin-right: 10px;
-  }
+#bpm-input {
+  width: 75px;
+  border: 2px solid #CCCCCC;
+  font-size: 2.5em;
+  margin-right: 10px;
+}
 
-  #bpm-select>span {
-      font-size: 2.5em;
-  }
+#bpm-select>span {
+  font-size: 2.5em;
+}
 
-  * {
-    -webkit-box-sizing: border-box;
-       -moz-box-sizing: border-box;
-            box-sizing: border-box;
-  }
+* {
+-webkit-box-sizing: border-box;
+   -moz-box-sizing: border-box;
+        box-sizing: border-box;
+}

--- a/style.css
+++ b/style.css
@@ -38,6 +38,7 @@
     text-align: center;
     flex: 1 0 0px;
     min-width: 1em;
+    line-height: 1;
     align-items: center;
     justify-content: center;
     background-color: #35A7FF;
@@ -73,7 +74,7 @@ body {
     width: 300px;
     height: 100px;
 
-    margin-top: 50px;
+    margin-top: 20px;
     display:flex;
     justify-content: center;
     align-items: center;
@@ -101,17 +102,25 @@ body {
     margin-top: 20px;
 }
 
+#flats-checkbox {
+    margin: 0 auto;
+    width: 300px;
+    font-size: 18px;
+    text-align: center;
+    margin-top: 10px;
+}
+
 #shuffle-button {
     margin: 0 auto;
     margin-top: 30px;
     width: 90px;
     height: 40px;
-    
+
     display: flex;
     justify-content: center;
     align-items: center;
     font-size: .5em;
-    
+
     color: white;
     background-color: rgb(11, 179, 123);
     box-shadow: 0px 6px 0px 0px rgb(7, 123, 84);


### PR DESCRIPTION
I added `line-height` to be `1` because the flat symbol has a longer line height which caused the note containers to be taller than the non-flat ones.